### PR TITLE
[修正] reviewdogの依存関係を手動でインストールするように変更

### DIFF
--- a/.github/workflows/pr-test-reviewdog.yml
+++ b/.github/workflows/pr-test-reviewdog.yml
@@ -13,6 +13,15 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+      - name: allow write in work dir
+        run: sudo chmod -R 777 .
+      - name: Install Dependencies
+        run: |
+          npm -g install pnpm
+          pnpm install
       - uses: reviewdog/action-eslint@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
npmによる依存関係のインストールがあまりにも遅いのでpnpmを使用するように変更