### PR TITLE
[実装] API呼び出しへのキャッシュ機能を追加

### DIFF
--- a/src/hooks/usePopulationComposition.ts
+++ b/src/hooks/usePopulationComposition.ts
@@ -10,43 +10,46 @@ export const usePopulationComposition = (prefCodes: number[]) => {
     useState<TApiResponse<Record<number, TPopulationCompositionResponse>>>();
   const [loading, setLoading] = useState<boolean>(false);
 
-  const fetchData = useCallback(async () => {
-    setLoading(true);
-    const response = await Promise.all(
-      prefCodes.map(async (prefCode) => {
-        return {
-          data: await getPopulationCompositionPerYear(prefCode),
-          prefCode,
-        };
-      }),
-    );
-    const isFailed = response.find((res) => res.data.type !== "success");
-    if (isFailed) {
-      setData({
-        type: "error",
-        data: isFailed.data.data as TErrorResponse,
-      });
-    } else {
-      const data = response.reduce(
-        (acc, res) => {
-          if (res.data.type !== "success") return acc;
+  const fetchData = useCallback(
+    async (forceUpdate = true) => {
+      setLoading(true);
+      const response = await Promise.all(
+        prefCodes.map(async (prefCode) => {
           return {
-            ...acc,
-            [res.prefCode]: res.data.data,
+            data: await getPopulationCompositionPerYear(prefCode, forceUpdate),
+            prefCode,
           };
-        },
-        {} as Record<string, TPopulationCompositionResponse>,
+        }),
       );
-      setData({
-        type: "success",
-        data,
-      });
-    }
-    setLoading(false);
-  }, [prefCodes]);
+      const isFailed = response.find((res) => res.data.type !== "success");
+      if (isFailed) {
+        setData({
+          type: "error",
+          data: isFailed.data.data as TErrorResponse,
+        });
+      } else {
+        const data = response.reduce(
+          (acc, res) => {
+            if (res.data.type !== "success") return acc;
+            return {
+              ...acc,
+              [res.prefCode]: res.data.data,
+            };
+          },
+          {} as Record<string, TPopulationCompositionResponse>,
+        );
+        setData({
+          type: "success",
+          data,
+        });
+      }
+      setLoading(false);
+    },
+    [prefCodes],
+  );
 
   useEffect(() => {
-    void fetchData();
+    void fetchData(false);
   }, [fetchData]);
 
   return { data, loading, refetch: fetchData };

--- a/src/hooks/usePrefectures.ts
+++ b/src/hooks/usePrefectures.ts
@@ -8,15 +8,15 @@ export const usePrefectures = () => {
   const [data, setData] = useState<TApiResponse<TPrefectureResponse>>();
   const [loading, setLoading] = useState<boolean>(false);
 
-  const fetchData = async () => {
+  const fetchData = async (forceUpdate = true) => {
     setLoading(true);
-    const response = await getPrefectures();
+    const response = await getPrefectures(forceUpdate);
     setData(response);
     setLoading(false);
   };
 
   useEffect(() => {
-    void fetchData();
+    void fetchData(false);
   }, []);
   return { data, loading, refetch: fetchData };
 };

--- a/src/hooks/usePrefectures.ts
+++ b/src/hooks/usePrefectures.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { TPrefectureResponse } from "@/@types/api/prefectures.ts";
 import { TApiResponse } from "@/@types/api/response";
@@ -8,15 +8,15 @@ export const usePrefectures = () => {
   const [data, setData] = useState<TApiResponse<TPrefectureResponse>>();
   const [loading, setLoading] = useState<boolean>(false);
 
-  const fetchData = async (forceUpdate = true) => {
+  const fetchData = useCallback(async (forceUpdate = true) => {
     setLoading(true);
     const response = await getPrefectures(forceUpdate);
     setData(response);
     setLoading(false);
-  };
+  }, []);
 
   useEffect(() => {
     void fetchData(false);
-  }, []);
+  }, [fetchData]);
   return { data, loading, refetch: fetchData };
 };

--- a/src/services/getPopulationCompositionPerYear.ts
+++ b/src/services/getPopulationCompositionPerYear.ts
@@ -6,19 +6,32 @@ import {
 import { TApiResponse } from "@/@types/api/response";
 import { requests } from "@/lib/requests.ts";
 
+const cache: Record<number, TPopulationCompositionResponse> = {};
+
 export const getPopulationCompositionPerYear = async (
   prefCode: number,
+  forceUpdate = false,
 ): Promise<TApiResponse<TPopulationCompositionResponse>> => {
+  const cacheItem = cache[prefCode];
+  if (!forceUpdate && cacheItem) {
+    return {
+      type: "success",
+      data: cacheItem,
+    };
+  }
+
   const data = await requests(
     `/population/composition/perYear?prefCode=${prefCode}&cityCode=-`,
   );
   const result = ZPopulationCompositionResponse.safeParse(data);
   if (result.success) {
+    cache[prefCode] = result.data;
     return {
       type: "success",
       data: result.data,
     };
   }
+  delete cache[prefCode];
   const error = ZErrorResponse.safeParse(data);
   if (error.success) {
     return {

--- a/src/services/getPrefectures.ts
+++ b/src/services/getPrefectures.ts
@@ -6,17 +6,28 @@ import {
 import { TApiResponse } from "@/@types/api/response";
 import { requests } from "@/lib/requests.ts";
 
-export const getPrefectures = async (): Promise<
-  TApiResponse<TPrefectureResponse>
-> => {
+let cache: TPrefectureResponse | undefined = undefined;
+
+export const getPrefectures = async (
+  forceUpdate = false,
+): Promise<TApiResponse<TPrefectureResponse>> => {
+  if (!forceUpdate && cache) {
+    return {
+      type: "success",
+      data: cache,
+    };
+  }
+
   const data = await requests(`/prefectures`);
   const result = ZPrefectureResponse.safeParse(data);
   if (result.success) {
+    cache = result.data;
     return {
       type: "success",
       data: result.data,
     };
   }
+  cache = undefined;
   const error = ZErrorResponse.safeParse(data);
   if (error.success) {
     return {


### PR DESCRIPTION
APIにレートリミットがあるのでキャッシュを用いてリミットに引っかからないように対策