### PR TITLE
[修正] graphコンポーネントを調整

### DIFF
--- a/src/components/graph/graph.tsx
+++ b/src/components/graph/graph.tsx
@@ -1,3 +1,5 @@
+import "./rechart.scss";
+
 import { FC, useEffect, useState } from "react";
 import {
   CartesianGrid,

--- a/src/components/graph/graph.tsx
+++ b/src/components/graph/graph.tsx
@@ -32,6 +32,7 @@ export const Graph: FC<Props> = ({ data, range, onRangeChange }) => {
     getVerticalRange(data),
   );
   const [hiddenKeys, setHiddenKeys] = useState<string[]>([]);
+  const [colors, setColors] = useState<Record<string, string>>({});
 
   const zoom = () => {
     setDragStart(undefined);
@@ -57,6 +58,18 @@ export const Graph: FC<Props> = ({ data, range, onRangeChange }) => {
   useEffect(() => {
     setVerticalRange(getVerticalRange(data, range));
   }, [data, range]);
+
+  useEffect(() => {
+    const keys = Object.keys(data[0]).filter((key) => key !== "name");
+    setColors((pv) => {
+      for (const key of keys) {
+        pv[key] ??= `#${Math.floor(Math.random() * 16777215)
+          .toString(16)
+          .padStart(6, "0")}`;
+      }
+      return { ...pv };
+    });
+  }, [data]);
 
   return (
     <ResponsiveContainer width="100%" height={400}>
@@ -85,7 +98,7 @@ export const Graph: FC<Props> = ({ data, range, onRangeChange }) => {
               key={key}
               type="natural"
               dataKey={key}
-              stroke="#8884d8"
+              stroke={colors[key]}
               hide={hiddenKeys.includes(key)}
             />
           ))}

--- a/src/components/graph/rechart.scss
+++ b/src/components/graph/rechart.scss
@@ -1,0 +1,5 @@
+.recharts-default-tooltip {
+  color: var(--text-body) !important;
+  background: var(--background-tertiary) !important;
+  border: 1px solid var(--border-field) !important;
+}


### PR DESCRIPTION
- ズーム時の内部処理を修正
- rechartのデフォルトスタイルを上書き
- 各都道府県の色をシャッフルするように変更