### PR TITLE
[修正] dropdownコンポーネントのスタイルを修正

### DIFF
--- a/src/components/dropdown/dropdown.module.scss
+++ b/src/components/dropdown/dropdown.module.scss
@@ -22,7 +22,7 @@
     }
     .select {
       color: var(--text-body);
-      padding: 16px;
+      padding: 16px 32px 16px 16px;
       appearance: none;
       border: solid 1px var(--border-field);
       background: var(--background-primary);


### PR DESCRIPTION
下矢印と文字列が被ってしまっていたため修正